### PR TITLE
compatable with guard 1.1

### DIFF
--- a/lib/guard/jshint-node.rb
+++ b/lib/guard/jshint-node.rb
@@ -20,8 +20,8 @@ module Guard
 
 		# Called on file(s) modifications that the Guard watches.
 		# @param [Array<String>] paths the changes files or paths
-		# @raise [:task_has_failed] when run_on_change has failed
-		def run_on_change(paths)
+		# @raise [:task_has_failed] when run_on_changes has failed
+		def run_on_changes(paths)
 			paths.each do |path|
 
 				is_old_version = (Gem::Version.new(`jshint --version`) < Gem::Version.new('0.5.2'))

--- a/spec/guard/jshint-node_spec.rb
+++ b/spec/guard/jshint-node_spec.rb
@@ -5,14 +5,14 @@ describe Guard::JshintNode do
 
 	subject { Guard::JshintNode.new }
 
-	describe "#run_on_change" do
+	describe "#run_on_changes" do
 
 		it "with good file" do
-			subject.run_on_change(['spec/fixtures/good.js']).should == true
+			subject.run_on_changes(['spec/fixtures/good.js']).should == true
 		end
 
 		it "with bad file" do
-			subject.run_on_change(['spec/fixtures/bad.js']).should == false
+			subject.run_on_changes(['spec/fixtures/bad.js']).should == false
 		end
 
 	end


### PR DESCRIPTION
got a deprecation warning:

```
DEPRECATION: Starting with Guard v1.1 the use of the 'run_on_change' method in the 'Guard::JshintNode' guard is deprecated.
Please consider replacing that method-call with 'run_on_changes' if the type of change
is not important for your usecase or using either 'run_on_modifications' or 'run_on_additions'
based on the type of the changes you want to handle.
For more information on how to update existing guards, please head over to:
https://github.com/guard/guard/wiki/Upgrade-guide-for-existing-guards-to-Guard-v1.1
```

this patch contains that suggested change.
I do not know if this will break guards prior to 1.1.
